### PR TITLE
Flesh out metadata needed for UI landing/detail pages

### DIFF
--- a/handlers/dataresource/handler.go
+++ b/handlers/dataresource/handler.go
@@ -1,0 +1,64 @@
+package dataresource
+
+import (
+	"encoding/json"
+	"github.com/ONSdigital/dp-dd-api-stub/models"
+	"net/http"
+)
+
+func Handler(w http.ResponseWriter, req *http.Request) {
+	var stubData map[string]*models.DataResource = make(map[string]*models.DataResource)
+
+	stubData["AF001EW"] = &models.DataResource{
+		ID:    "AF001EW",
+		Title: "AF001EW  Members of the Armed Forces by residence type by sex by age",
+		Metadata: &models.Metadata{
+			Description:        "This dataset provides 2011 Census estimates that classify usual residents aged 16 and over who are members of the armed forces by residence type (household or communal resident), by sex and by age. The estimates are as at census day, 27 March 2011.",
+			NationalStatistics: true,
+			Contact: &models.Contact{
+				Name:  "Alexa Bradley",
+				Phone: "+44 (0)1329 444972",
+				Email: "pop.info@ons.gsi.gov.uk",
+			},
+			ReleaseDate: "23 May 2014",
+			NextRelease: "To be announced",
+			Publications: []*models.Publication{
+				{DatasetID: "AF002", Title: "AF002 Household Reference Persons (HRPs) who are members of the Armed Forces and associated persons in households with members of the Armed Forces by sex by age, local authorities in England and Wales"},
+				{DatasetID: "AF003", Title: "AF003 Economic activity of associated people in households with members of the Armed Forces by sex, local authorities in England and Wales"},
+				{DatasetID: "AF004", Title: "AF004 Members of the Armed Forces by workplace address by sex by age, local authorities in England and Wales"},
+			},
+		},
+		Datasets: []string{"http://localhost:20099/datasets/AF001EW"},
+	}
+
+	stubData["CPI15"] = &models.DataResource{
+		ID:    "CPI15",
+		Title: "CPI15 Consumer Prices Index (COICOP).",
+		Metadata: &models.Metadata{
+			Description:        "Consumer Price Index statistics by Time and Special Aggregate (type of economic activity). This dataset shows the movement of prices over the last five years within the UK economy, broken down by month and various classifications of economic activity. The economic classifications are derived from the COICOP (Classification Of Individual Consumption by Purpose) list.",
+			NationalStatistics: true,
+			Contact: &models.Contact{
+				Name:  "James Tucker",
+				Email: "cpi@ons.gsi.gov.uk",
+				Phone: "+44 (0)1633 456900",
+			},
+			ReleaseDate: "17 January 2017",
+			NextRelease: "14 February 2017",
+			Methodology: []*models.Methodology{
+				{Title: "Consumer Price Inflation (includes all 4 indices—CPI, CPIH, RPI and RPIJ)", URL: "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi"},
+			},
+		},
+		Datasets: []string{"http://localhost:20099/datasets/CPI15"},
+	}
+
+	datasetID := req.URL.Query().Get(":resourceId")
+	if _, ok := stubData[datasetID]; !ok {
+		w.WriteHeader(404)
+		return
+	}
+
+	jsonEncoder := json.NewEncoder(w)
+	jsonEncoder.Encode(stubData[datasetID])
+
+	w.WriteHeader(200)
+}

--- a/handlers/dataresource/handler.go
+++ b/handlers/dataresource/handler.go
@@ -22,10 +22,10 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 			},
 			ReleaseDate: "23 May 2014",
 			NextRelease: "To be announced",
-			Publications: []*models.Publication{
-				{DatasetID: "AF002", Title: "AF002 Household Reference Persons (HRPs) who are members of the Armed Forces and associated persons in households with members of the Armed Forces by sex by age, local authorities in England and Wales"},
-				{DatasetID: "AF003", Title: "AF003 Economic activity of associated people in households with members of the Armed Forces by sex, local authorities in England and Wales"},
-				{DatasetID: "AF004", Title: "AF004 Members of the Armed Forces by workplace address by sex by age, local authorities in England and Wales"},
+			Publications: []string{
+				"http://localhost:20099/datasets/AF002",
+				"http://localhost:20099/datasets/AF003",
+				"http://localhost:20099/datasets/AF004",
 			},
 		},
 		Datasets: []string{"http://localhost:20099/datasets/AF001EW"},

--- a/handlers/dataset/handler.go
+++ b/handlers/dataset/handler.go
@@ -2,8 +2,8 @@ package dataset
 
 import (
 	"encoding/json"
-	"net/http"
 	"github.com/ONSdigital/dp-dd-api-stub/models"
+	"net/http"
 )
 
 func Handler(w http.ResponseWriter, req *http.Request) {
@@ -11,11 +11,27 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 	var stubData map[string]*models.Dataset = make(map[string]*models.Dataset)
 
 	stubData["AF001EW"] = &models.Dataset{
-		ID:    "AF001EW",
-		Title: "AF001EW  Members of the Armed Forces by residence type by sex by age",
-		URL:   "http://localhost:20099/datasets/AF001EW",
+		ID:               "AF001EW",
+		CustomerFacingID: "AF001EW",
+		Title:            "AF001EW  Members of the Armed Forces by residence type by sex by age",
+		URL:              "http://localhost:20099/datasets/AF001EW",
 		Metadata: &models.Metadata{
-			Description: "This dataset provides 2011 Census estimates that classify usual residents aged 16 and over who are members of the armed forces by residence type (household or communal resident), by sex and by age. The estimates are as at census day, 27 March 2011.",
+			Description:        "This dataset provides 2011 Census estimates that classify usual residents aged 16 and over who are members of the armed forces by residence type (household or communal resident), by sex and by age. The estimates are as at census day, 27 March 2011.",
+			NationalStatistics: true,
+			Contact: &models.Contact{
+				Name:  "Alexa Bradley",
+				Phone: "+44 (0)1329 444972",
+				Email: "pop.info@ons.gsi.gov.uk",
+			},
+			ReleaseDate: "23 May 2014",
+			NextRelease: "To be announced",
+			Publications: []*models.Publication{
+				{DatasetID: "AF002", Title: "AF002 Household Reference Persons (HRPs) who are members of the Armed Forces and associated persons in households with members of the Armed Forces by sex by age, local authorities in England and Wales"},
+				{DatasetID: "AF003", Title: "AF003 Economic activity of associated people in households with members of the Armed Forces by sex, local authorities in England and Wales"},
+				{DatasetID: "AF004", Title: "AF004 Members of the Armed Forces by workplace address by sex by age, local authorities in England and Wales"},
+			},
+			Comments:           "N/A",
+			TermsAndConditions: "N/A",
 		},
 		Dimensions: []*models.Dimension{
 			{ID: "D000125", Name: "Sex"},
@@ -30,11 +46,24 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 		Title: "CPI15 Consumer Prices Index (COICOP).",
 		URL:   "http://localhost:20099/datasets/CPI15",
 		Metadata: &models.Metadata{
-			Description: "This dataset provides 2011 Census estimates that classify usual residents aged 16 and over who are members of the armed forces by residence type (household or communal resident), by sex and by age. The estimates are as at census day, 27 March 2011.",
+			Description:        "Consumer Price Index statistics by Time and Special Aggregate (type of economic activity). This dataset shows the movement of prices over the last five years within the UK economy, broken down by month and various classifications of economic activity. The economic classifications are derived from the COICOP (Classification Of Individual Consumption by Purpose) list.",
+			NationalStatistics: true,
+			Contact: &models.Contact{
+				Name:  "James Tucker",
+				Email: "cpi@ons.gsi.gov.uk",
+				Phone: "+44 (0)1633 456900",
+			},
+			ReleaseDate: "17 January 2017",
+			NextRelease: "14 February 2017",
+			Methodology: []*models.Methodology{
+				{Title: "Consumer Price Inflation (includes all 4 indices—CPI, CPIH, RPI and RPIJ)", URL: "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi"},
+			},
+			Comments:           "N/A",
+			TermsAndConditions: "",
 		},
 		Dimensions: []*models.Dimension{
-			{ID:   "SP00001", Name: "Special aggregate"},
-			{ID:   "T000111", Name: "Time"},
+			{ID: "SP00001", Name: "Special aggregate"},
+			{ID: "T000111", Name: "Time"},
 		},
 	}
 

--- a/handlers/dataset/handler.go
+++ b/handlers/dataset/handler.go
@@ -25,12 +25,11 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 			},
 			ReleaseDate: "23 May 2014",
 			NextRelease: "To be announced",
-			Publications: []*models.Publication{
-				{DatasetID: "AF002", Title: "AF002 Household Reference Persons (HRPs) who are members of the Armed Forces and associated persons in households with members of the Armed Forces by sex by age, local authorities in England and Wales"},
-				{DatasetID: "AF003", Title: "AF003 Economic activity of associated people in households with members of the Armed Forces by sex, local authorities in England and Wales"},
-				{DatasetID: "AF004", Title: "AF004 Members of the Armed Forces by workplace address by sex by age, local authorities in England and Wales"},
+			Publications: []string{
+				"http://localhost:20099/datasets/AF002",
+				"http://localhost:20099/datasets/AF003",
+				"http://localhost:20099/datasets/AF004",
 			},
-			Comments:           "N/A",
 			TermsAndConditions: "N/A",
 		},
 		Dimensions: []*models.Dimension{
@@ -58,7 +57,6 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 			Methodology: []*models.Methodology{
 				{Title: "Consumer Price Inflation (includes all 4 indices—CPI, CPIH, RPI and RPIJ)", URL: "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi"},
 			},
-			Comments:           "N/A",
 			TermsAndConditions: "",
 		},
 		Dimensions: []*models.Dimension{

--- a/handlers/datasets/handler.go
+++ b/handlers/datasets/handler.go
@@ -11,18 +11,48 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 	var stubData models.Datasets = models.Datasets{}
 
 	stubData.Items = []*models.Dataset{{
-		ID:    "AF001EW",
-		Title: "AF001EW  Members of the Armed Forces by residence type by sex by age",
-		URL:   "http://localhost:20099/datasets/AF001EW",
+		ID:               "AF001EW",
+		CustomerFacingID: "AF001EW",
+		Title:            "AF001EW  Members of the Armed Forces by residence type by sex by age",
+		URL:              "http://localhost:20099/datasets/AF001EW",
 		Metadata: &models.Metadata{
-			Description: "This dataset provides 2011 Census estimates that classify usual residents aged 16 and over who are members of the armed forces by residence type (household or communal resident), by sex and by age. The estimates are as at census day, 27 March 2011.",
+			Description:        "This dataset provides 2011 Census estimates that classify usual residents aged 16 and over who are members of the armed forces by residence type (household or communal resident), by sex and by age. The estimates are as at census day, 27 March 2011.",
+			NationalStatistics: true,
+			Contact: &models.Contact{
+				Name:  "Alexa Bradley",
+				Phone: "+44 (0)1329 444972",
+				Email: "pop.info@ons.gsi.gov.uk",
+			},
+			ReleaseDate: "23 May 2014",
+			NextRelease: "To be announced",
+			Publications: []*models.Publication{
+				{DatasetID: "AF002", Title: "AF002 Household Reference Persons (HRPs) who are members of the Armed Forces and associated persons in households with members of the Armed Forces by sex by age, local authorities in England and Wales"},
+				{DatasetID: "AF003", Title: "AF003 Economic activity of associated people in households with members of the Armed Forces by sex, local authorities in England and Wales"},
+				{DatasetID: "AF004", Title: "AF004 Members of the Armed Forces by workplace address by sex by age, local authorities in England and Wales"},
+			},
+			Comments:           "N/A",
+			TermsAndConditions: "N/A",
 		},
 	}, {
-		ID:    "CPI15",
-		Title: "CPI15 Consumer Prices Index (COICOP).",
-		URL:   "http://localhost:20099/datasets/CPI15",
+		ID:               "CPI15",
+		CustomerFacingID: "CPI15",
+		Title:            "CPI15 Consumer Prices Index (COICOP).",
+		URL:              "http://localhost:20099/datasets/CPI15",
 		Metadata: &models.Metadata{
-			Description: "Consumer Price Index statistics by Time and Special Aggregate (type of economic activity). This dataset shows the movement of prices over the last five years within the UK economy, broken down by month and various classifications of economic activity. The economic classifications are derived from the COICOP (Classification Of Individual Consumption by Purpose) list.",
+			Description:        "Consumer Price Index statistics by Time and Special Aggregate (type of economic activity). This dataset shows the movement of prices over the last five years within the UK economy, broken down by month and various classifications of economic activity. The economic classifications are derived from the COICOP (Classification Of Individual Consumption by Purpose) list.",
+			NationalStatistics: true,
+			Contact: &models.Contact{
+				Name:  "James Tucker",
+				Email: "cpi@ons.gsi.gov.uk",
+				Phone: "+44 (0)1633 456900",
+			},
+			ReleaseDate: "17 January 2017",
+			NextRelease: "14 February 2017",
+			Methodology: []*models.Methodology{
+				{Title: "Consumer Price Inflation (includes all 4 indices—CPI, CPIH, RPI and RPIJ)", URL: "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi"},
+			},
+			Comments:           "N/A",
+			TermsAndConditions: "",
 		},
 	}}
 

--- a/handlers/datasets/handler.go
+++ b/handlers/datasets/handler.go
@@ -25,12 +25,11 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 			},
 			ReleaseDate: "23 May 2014",
 			NextRelease: "To be announced",
-			Publications: []*models.Publication{
-				{DatasetID: "AF002", Title: "AF002 Household Reference Persons (HRPs) who are members of the Armed Forces and associated persons in households with members of the Armed Forces by sex by age, local authorities in England and Wales"},
-				{DatasetID: "AF003", Title: "AF003 Economic activity of associated people in households with members of the Armed Forces by sex, local authorities in England and Wales"},
-				{DatasetID: "AF004", Title: "AF004 Members of the Armed Forces by workplace address by sex by age, local authorities in England and Wales"},
+			Publications: []string{
+				"http://localhost:20099/datasets/AF002",
+				"http://localhost:20099/datasets/AF003",
+				"http://localhost:20099/datasets/AF004",
 			},
-			Comments:           "N/A",
 			TermsAndConditions: "N/A",
 		},
 	}, {
@@ -51,7 +50,6 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 			Methodology: []*models.Methodology{
 				{Title: "Consumer Price Inflation (includes all 4 indices—CPI, CPIH, RPI and RPIJ)", URL: "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi"},
 			},
-			Comments:           "N/A",
 			TermsAndConditions: "",
 		},
 	}}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	router.Get("/datasets/{datasetId}", dataset.Handler)                            // provide detailed information for a given dataset
 	router.Get("/datasets", datasets.Handler)                                       // list high level dataset
 	router.Get("/download", download.Handler)                                       // list high level dataset
-	router.Get("/dataresource/{resourceId}", dataresource.Handler)
+	router.Get("/dataresources/{resourceId}", dataresource.Handler)
 
 	// Geographic Hierarchies and Areas
 	// http://localhost:20099/geoareas/?geoareatype=COUNTRY				// returns list of all geographical areas within an entity (e.g. Metropolitan Districts)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/ONSdigital/dp-dd-api-stub/handlers/data"
+	"github.com/ONSdigital/dp-dd-api-stub/handlers/dataresource"
 	"github.com/ONSdigital/dp-dd-api-stub/handlers/dataset"
 	"github.com/ONSdigital/dp-dd-api-stub/handlers/datasets"
 	"github.com/ONSdigital/dp-dd-api-stub/handlers/dimension"
@@ -46,6 +47,7 @@ func main() {
 	router.Get("/datasets/{datasetId}", dataset.Handler)                            // provide detailed information for a given dataset
 	router.Get("/datasets", datasets.Handler)                                       // list high level dataset
 	router.Get("/download", download.Handler)                                       // list high level dataset
+	router.Get("/dataresource/{resourceId}", dataresource.Handler)
 
 	// Geographic Hierarchies and Areas
 	// http://localhost:20099/geoareas/?geoareatype=COUNTRY				// returns list of all geographical areas within an entity (e.g. Metropolitan Districts)

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -45,6 +45,13 @@ type Datasets struct {
 	ItemsPerPage int        `json:"itemsPerPage"`
 }
 
+type DataResource struct {
+	ID       string    `json:"id"`
+	Title    string    `json:"title"`
+	Metadata *Metadata `json:"metadata"`
+	Datasets []string  `json:"datasets"`
+}
+
 type Dataset struct {
 	ID               string       `json:"id"`
 	CustomerFacingID string       `json:"customerFacingId"`
@@ -98,8 +105,8 @@ type Metadata struct {
 	NationalStatistics bool           `json:"nationalStatistics"` // whether these are official National Statistics
 	Publications       []*Publication `json:"associatedPublications"`
 	Methodology        []*Methodology `json:"methodology"`
-	Comments           string         `json:"datasetInternalMetadata"`
-	TermsAndConditions string         `json:"termsAndConditions"`
+	Comments           string         `json:"datasetInternalMetadata,omitempty"`
+	TermsAndConditions string         `json:"termsAndConditions,omitempty"`
 }
 
 type Publication struct {

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -46,12 +46,13 @@ type Datasets struct {
 }
 
 type Dataset struct {
-	ID         string       `json:"id"`
-	Title      string       `json:"title"`
-	URL        string       `json:"url,omitempty"`
-	Metadata   *Metadata    `json:"metadata,omitempty"`
-	Dimensions []*Dimension `json:"dimensions,omitempty"`
-	Data       *Table       `json:"data,omitempty"`
+	ID               string       `json:"id"`
+	CustomerFacingID string       `json:"customerFacingId"`
+	Title            string       `json:"title"`
+	URL              string       `json:"url,omitempty"`
+	Metadata         *Metadata    `json:"metadata,omitempty"`
+	Dimensions       []*Dimension `json:"dimensions,omitempty"`
+	Data             *Table       `json:"data,omitempty"`
 }
 
 type GeoArea struct {
@@ -89,8 +90,33 @@ type TimeType struct {
 }
 
 type Metadata struct {
-	Description string   `json:"description,omitempty"`
-	Taxonomies  []string `json:"taxonomies,omitempty"`
+	Description        string         `json:"description,omitempty"`
+	Taxonomies         []string       `json:"taxonomies,omitempty"`
+	Contact            *Contact       `json:"contact"`
+	ReleaseDate        string         `json:"releaseDate"`
+	NextRelease        string         `json:"nextReleaseDate"`
+	NationalStatistics bool           `json:"nationalStatistics"` // whether these are official National Statistics
+	Publications       []*Publication `json:"associatedPublications"`
+	Methodology        []*Methodology `json:"methodology"`
+	Comments           string         `json:"datasetInternalMetadata"`
+	TermsAndConditions string         `json:"termsAndConditions"`
+}
+
+type Publication struct {
+	Title     string `json:"title"`
+	URL       string `json:"url,omitempty"`
+	DatasetID string `json:"datasetId,omitempty"`
+}
+
+type Contact struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+	Phone string `json:"phone,omitempty"`
+}
+
+type Methodology struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
 }
 
 type Dimension struct {

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -103,16 +103,9 @@ type Metadata struct {
 	ReleaseDate        string         `json:"releaseDate"`
 	NextRelease        string         `json:"nextReleaseDate"`
 	NationalStatistics bool           `json:"nationalStatistics"` // whether these are official National Statistics
-	Publications       []*Publication `json:"associatedPublications"`
+	Publications       []string       `json:"associatedPublications"`
 	Methodology        []*Methodology `json:"methodology"`
-	Comments           string         `json:"datasetInternalMetadata,omitempty"`
 	TermsAndConditions string         `json:"termsAndConditions,omitempty"`
-}
-
-type Publication struct {
-	Title     string `json:"title"`
-	URL       string `json:"url,omitempty"`
-	DatasetID string `json:"datasetId,omitempty"`
 }
 
 type Contact struct {


### PR DESCRIPTION
### What

Adds various descriptive metadata elements to the stub API to support the UI development of the dataset landing and detail pages. The `metadata` element for a dataset (which previously just contained a description) now looks like the following:

```javascript
"metadata": {
    "description": "This dataset provides 2011 Census estimates that classify usual residents aged 16 and over who are members of the armed forces by residence type (household or communal resident), by sex and by age. The estimates are as at census day, 27 March 2011.",
    "contact": {
        "name": "Alexa Bradley",
        "email": "pop.info@ons.gsi.gov.uk",
        "phone": "+44 (0)1329 444972"
    },
    "releaseDate": "23 May 2014",
    "nextReleaseDate": "To be announced",
    "nationalStatistics": true, // Whether this is an official National Statistics dataset
    "associatedPublications": [ // Links to datasets that use this data
        "http://localhost:20099/datasets/AF002",
        "http://localhost:20099/datasets/AF003",
        "http://localhost:20099/datasets/AF004"
    ],
    "methodology": "http://....", // Link to page describing the methodology
    "termsAndConditions": "N/A"
}
```

I've also added a new `/dataresources/XXX` route for getting metadata on an overall data resource. This largely duplicates the same data as above, but missing a few fields. It's not clear yet whether this will be separately entered data or derived from the most recent dataset. I've not added a top-level `/dataresources` route for querying all data resources as I don't think that needs to exist (you always enter the system on a particular resource landing page). The data resource also links to each of the individual data sets under that resource - implicitly in order of major/minor version number, but with no further metadata.

Finally, there is a new `customerFacingId` element on the datasets that will show the public ID used for that dataset/resource (i.e. "AF001EW" in the above example) as opposed to the random UUID we store in the database.

All of this is subject to iteration as we get feedback from the web team.

### How to review

`make debug` and go to `http://localhost:20099/datasets` and `http://localhost:20099/dataresources/AF001EW` and check the metadata looks right.

### Who can review

Anyone but me. Particular important for @fullstackforger / @Crispioso and the web team.