### PR TITLE
Dataset with no (and some) metadata added

### DIFF
--- a/handlers/datasets/handler.go
+++ b/handlers/datasets/handler.go
@@ -52,6 +52,17 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 			},
 			TermsAndConditions: "",
 		},
+	}, {
+		ID:               "NO-META",
+		CustomerFacingID: "NO-META",
+		Title:            "Fake dataset with missing metadata field",
+		URL:              "http://localhost:20099/datasets/NO-META",
+	}, {
+		ID:               "EMPTY-META",
+		CustomerFacingID: "EMPTY-META",
+		Title:            "Fake dataset with empty metadata",
+		URL:              "http://localhost:20099/datasets/EMPTY-META",
+		Metadata:         &models.Metadata{},
 	}}
 
 	stubData.Count = len(stubData.Items)


### PR DESCRIPTION
**What?**

Added 2 fake endpoints so we can run/test FE against `/datasets/` endpoint with empty or missing `metadata` field.

Quite self-explanatory change:
https://github.com/ONSdigital/dp-dd-api-stub/pull/11/commits/66bf45a04029702f53a291f0a82dbf7117399b93

**Who can review**
Anyone but me