### PR TITLE
Empty (and NO) metadata datasets added to metadata/{id} endpoint

### DIFF
--- a/handlers/dataset/handler.go
+++ b/handlers/dataset/handler.go
@@ -65,6 +65,21 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 		},
 	}
 
+	stubData["NO-META"] = &models.Dataset{
+		ID:               "NO-META",
+		CustomerFacingID: "NO-META",
+		Title:            "Fake dataset with missing metadata field",
+		URL:              "http://localhost:20099/datasets/NO-META",
+	}
+
+	stubData["EMPTY-META"] = &models.Dataset{
+		ID:               "EMPTY-META",
+		CustomerFacingID: "EMPTY-META",
+		Title:            "Fake dataset with empty metadata",
+		URL:              "http://localhost:20099/datasets/EMPTY-META",
+		Metadata:         &models.Metadata{},
+	}
+
 	datasetID := req.URL.Query().Get(":datasetId")
 	if _, ok := stubData[datasetID]; !ok {
 		w.WriteHeader(404)


### PR DESCRIPTION
What?

Added 2 fake endpoints so we can run/test FE against `/datasets/ {id}` endpoint with empty or missing metadata field.

Quite self-explanatory change:
https://github.com/ONSdigital/dp-dd-api-stub/compare/feature-missing-metadata?expand=1#diff-0674d25681feed837431e5738a954cdb

Who can review
Anyone but me